### PR TITLE
Release 1.3.3

### DIFF
--- a/Rhizome.xcodeproj/project.pbxproj
+++ b/Rhizome.xcodeproj/project.pbxproj
@@ -1488,7 +1488,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1535,7 +1535,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1660,7 +1660,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1692,7 +1692,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1803,7 +1803,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1834,7 +1834,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -1919,7 +1919,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = Rhizome;
 				SDKROOT = macosx;
@@ -1957,7 +1957,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = Rhizome;
 				SDKROOT = macosx;

--- a/Rhizome/QueryFlux.swift
+++ b/Rhizome/QueryFlux.swift
@@ -7,28 +7,6 @@
 
 import Foundation
 
-class BasicAuthDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
-    let user: String
-    let password: String
-
-    init(user: String, password: String) {
-        self.user = user
-        self.password = password
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        task: URLSessionTask,
-        didReceive challenge: URLAuthenticationChallenge
-    ) async -> (URLSession.AuthChallengeDisposition, URLCredential?) {
-        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic {
-            let credential = URLCredential(user: user, password: password, persistence: .forSession)
-            return (.useCredential, credential)
-        }
-        return (.performDefaultHandling, nil)
-    }
-}
-
 func queryFlux(password: String) {
     let scheme: String = "https"
     let host: String = "api.fluxhaus.io"
@@ -49,9 +27,23 @@ func queryFlux(password: String) {
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
     request.addValue("application/json", forHTTPHeaderField: "Accept")
 
-    let delegate = BasicAuthDelegate(user: "rhizome", password: password)
-    let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-    let task = session.dataTask(with: request) { @Sendable data, _, error in
+    let credentialData = Data("rhizome:\(password)".utf8)
+    let base64Credential = credentialData.base64EncodedString()
+    request.setValue("Basic \(base64Credential)", forHTTPHeaderField: "Authorization")
+
+    let session = URLSession(configuration: .default)
+    let task = session.dataTask(with: request) { @Sendable data, response, error in
+        let httpResponse = response as? HTTPURLResponse
+        if httpResponse?.statusCode == 401 {
+            DispatchQueue.main.async { @MainActor in
+                NotificationCenter.default.post(
+                    name: Notification.Name.loginsUpdated,
+                    object: nil,
+                    userInfo: ["loginError": "Incorrect Password"]
+                )
+            }
+            return
+        }
         handleQueryFluxResponse(data: data, error: error, password: password)
     }
     task.resume()


### PR DESCRIPTION
## Release 1.3.3

### Bug Fixes

- **Fix authentication**: Replaced broken URL-embedded credentials (`URLComponents.user/.password`) with preemptive `Authorization: Basic` headers. URLSession no longer picks up credentials from URLs on modern Apple platforms.
- **Fix wrong password handling**: The URLSession delegate had no `previousFailureCount` check, causing infinite 401 retries on wrong passwords that would hammer the server and trigger rate limits. Now explicitly checks HTTP 401 and shows "Incorrect Password" immediately.

### Version

`MARKETING_VERSION` bumped from 1.3.2 → 1.3.3