### PR TITLE
Add multi-camera switching, screenshots, and video recording (v1.4.0)

### DIFF
--- a/Rhizome.xcodeproj/project.pbxproj
+++ b/Rhizome.xcodeproj/project.pbxproj
@@ -1677,7 +1677,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1724,7 +1724,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -1849,7 +1849,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1881,7 +1881,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1992,7 +1992,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -2023,7 +2023,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = xros;
@@ -2108,7 +2108,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_MODULE_NAME = RhizomeMac;
 				PRODUCT_NAME = Rhizome;
@@ -2147,7 +2147,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome;
 				PRODUCT_MODULE_NAME = RhizomeMac;
 				PRODUCT_NAME = Rhizome;
@@ -2251,7 +2251,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome.watchkitapp;
 				PRODUCT_NAME = Rhizome;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2284,7 +2284,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.3;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = org.davidjensenius.Rhizome.watchkitapp;
 				PRODUCT_NAME = Rhizome;
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Rhizome/ContentView.swift
+++ b/Rhizome/ContentView.swift
@@ -9,14 +9,14 @@ import SwiftUI
 import AVKit
 
 struct ContentView: View {
-    var cameraURL: String
+    var cameras: [CameraFeed]
     var rhizomeSchedule: Appointments?
     @State var showVideo = false
     @State var inPlayroom = false
     @State var path = [Int]()
 
-    init(cameraURL: String, rhizomeSchedule: Appointments?) {
-        self.cameraURL = cameraURL
+    init(cameras: [CameraFeed], rhizomeSchedule: Appointments?) {
+        self.cameras = cameras
         self.rhizomeSchedule = rhizomeSchedule
     }
 
@@ -51,7 +51,7 @@ struct ContentView: View {
             }.navigationDestination(for: Int.self) { selection in
                 if selection == 1 {
                     HStack {
-                        VideoPlayerView(cameraURL: cameraURL)
+                        VideoPlayerView(cameras: cameras)
                             .ignoresSafeArea()
                     }
                     .toolbar(.hidden, for: .navigationBar)

--- a/Rhizome/Info.plist
+++ b/Rhizome/Info.plist
@@ -17,6 +17,8 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Rhizome saves screenshots and video clips from camera feeds to your photo library.</string>
 
 </dict>
 </plist>

--- a/Rhizome/Login.swift
+++ b/Rhizome/Login.swift
@@ -104,10 +104,36 @@ struct Service: Codable {
     let servicename, price: String
 }
 
+// MARK: - CameraFeed
+struct CameraFeed: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let url: String
+}
+
 struct LoginResponse: Decodable {
     let cameraURL: String
+    let romperURL: String?
+    let gymURL: String?
     let rhizomeSchedule: RhizomeSchedule
     let rhizomeData: RhizomeData
+
+    enum CodingKeys: String, CodingKey {
+        case cameraURL, rhizomeSchedule, rhizomeData
+        case romperURL
+        case gymURL
+    }
+
+    var cameraFeeds: [CameraFeed] {
+        var feeds = [CameraFeed(id: "toybox", name: "Toybox", url: cameraURL)]
+        if let url = romperURL, !url.isEmpty {
+            feeds.append(CameraFeed(id: "romper", name: "Romper", url: url))
+        }
+        if let url = gymURL, !url.isEmpty {
+            feeds.append(CameraFeed(id: "gym", name: "Gym", url: url))
+        }
+        return feeds
+    }
 }
 
 struct FluxObject {

--- a/Rhizome/RhizomeApp.swift
+++ b/Rhizome/RhizomeApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct RhizomeApp: App {
     @State private var whereWeAre = WhereWeAre()
-    @State var cameraURL = ""
+    @State var cameras: [CameraFeed] = []
     @State var images: [String] = []
     @State var rhizomeSchedule: Appointments?
     @State var newsUrl: String?
@@ -26,7 +26,7 @@ struct RhizomeApp: App {
                         if ((object.userInfo?["keysComplete"]) != nil) == true {
                             if object.object != nil {
                                 let configResponse = object.object! as? LoginResponse
-                                cameraURL = configResponse?.cameraURL ?? ""
+                                cameras = configResponse?.cameraFeeds ?? []
                                 images = configResponse?.rhizomeData.photos ?? []
                                 newsUrl = configResponse?.rhizomeData.news ?? nil
                                 rhizomeSchedule = configResponse?.rhizomeSchedule.appointments
@@ -43,7 +43,7 @@ struct RhizomeApp: App {
                 }
             } else {
                 TabView {
-                    ContentView(cameraURL: cameraURL, rhizomeSchedule: rhizomeSchedule)
+                    ContentView(cameras: cameras, rhizomeSchedule: rhizomeSchedule)
                         .tabItem {
                             Label("Watch", systemImage: "tv")
                         }

--- a/Rhizome/VideoPlayerView.swift
+++ b/Rhizome/VideoPlayerView.swift
@@ -75,6 +75,23 @@ struct PlayerViewController: UIViewControllerRepresentable {
         }
     }
 }
+#elseif os(macOS)
+struct PlayerNSView: NSViewRepresentable {
+    var player: AVPlayer?
+
+    func makeNSView(context: Context) -> AVPlayerView {
+        let view = AVPlayerView()
+        view.controlsStyle = .none
+        view.player = player
+        return view
+    }
+
+    func updateNSView(_ nsView: AVPlayerView, context: Context) {
+        if nsView.player != player {
+            nsView.player = player
+        }
+    }
+}
 #endif
 
 struct VideoPlayerView: View {
@@ -133,8 +150,9 @@ struct VideoPlayerView: View {
             Group {
                 #if os(iOS) || os(tvOS) || os(visionOS)
                 PlayerViewController(player: player)
-                #else
-                VideoPlayer(player: player)
+                #elseif os(macOS)
+                PlayerNSView(player: player)
+                    .ignoresSafeArea()
                 #endif
             }
             #if os(iOS) || os(tvOS) || os(visionOS)

--- a/Rhizome/VideoPlayerView.swift
+++ b/Rhizome/VideoPlayerView.swift
@@ -27,34 +27,98 @@ struct PlayerError: Identifiable {
 @MainActor
 class PlayerObserver: NSObject, ObservableObject {
     @Published var playerError: PlayerError?
+    @Published var isBuffering = false
+    @Published var needsRetry = false
+
     private var playerItem: AVPlayerItem?
+    private var player: AVPlayer?
     private var statusObservation: NSKeyValueObservation?
     private var errorObservation: NSKeyValueObservation?
+    private var timeControlObservation: NSKeyValueObservation?
+    private var bufferObservation: NSKeyValueObservation?
+    private var stalledObserver: Any?
+    private var failedObserver: Any?
 
-    func observe(playerItem: AVPlayerItem) {
+    func observe(player: AVPlayer, playerItem: AVPlayerItem) {
+        self.player = player
         self.playerItem = playerItem
-        statusObservation = playerItem.observe(\.status, options: [.new, .initial]) { [weak self] item, _ in
-            if item.status == .failed {
-                if let error = item.error {
-                    Task { @MainActor in
-                        self?.playerError = PlayerError(error: error)
-                    }
-                }
-            }
-        }
+        observeItemStatus(playerItem)
+        observeBuffering(playerItem)
+        observeTimeControl(player)
+        observeNotifications(playerItem)
+    }
 
-        errorObservation = playerItem.observe(\.error, options: [.new, .initial]) { [weak self] item, _ in
-            if let error = item.error {
-                Task { @MainActor in
+    // MARK: Private helpers
+
+    private func observeItemStatus(_ item: AVPlayerItem) {
+        statusObservation = item.observe(\.status, options: [.new, .initial]) { [weak self] obs, _ in
+            Task { @MainActor in
+                if obs.status == .failed, let error = obs.error {
                     self?.playerError = PlayerError(error: error)
+                    self?.needsRetry = true
                 }
             }
         }
     }
 
+    private func observeBuffering(_ item: AVPlayerItem) {
+        bufferObservation = item.observe(
+            \.isPlaybackLikelyToKeepUp,
+             options: [.new, .initial]
+        ) { [weak self] obs, _ in
+            Task { @MainActor in
+                if !obs.isPlaybackLikelyToKeepUp { self?.isBuffering = true }
+            }
+        }
+    }
+
+    private func observeTimeControl(_ avPlayer: AVPlayer) {
+        timeControlObservation = avPlayer.observe(
+            \.timeControlStatus,
+             options: [.new, .initial]
+        ) { [weak self] obs, _ in
+            Task { @MainActor in
+                switch obs.timeControlStatus {
+                case .playing:
+                    self?.isBuffering = false
+                    self?.needsRetry = false
+                case .waitingToPlayAtSpecifiedRate:
+                    self?.isBuffering = true
+                case .paused:
+                    self?.isBuffering = true
+                @unknown default:
+                    break
+                }
+            }
+        }
+    }
+
+    private func observeNotifications(_ item: AVPlayerItem) {
+        stalledObserver = NotificationCenter.default.addObserver(
+            forName: AVPlayerItem.playbackStalledNotification,
+            object: item, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.isBuffering = true; self?.needsRetry = true }
+        }
+
+        failedObserver = NotificationCenter.default.addObserver(
+            forName: AVPlayerItem.failedToPlayToEndTimeNotification,
+            object: item, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in self?.needsRetry = true }
+        }
+    }
+
     func stopObserving() {
         statusObservation?.invalidate()
-        errorObservation?.invalidate()
+        bufferObservation?.invalidate()
+        timeControlObservation?.invalidate()
+        if let stalledObserver { NotificationCenter.default.removeObserver(stalledObserver) }
+        if let failedObserver { NotificationCenter.default.removeObserver(failedObserver) }
+        stalledObserver = nil
+        failedObserver = nil
+        player = nil
+        playerItem = nil
     }
 }
 
@@ -94,6 +158,7 @@ struct PlayerNSView: NSViewRepresentable {
 }
 #endif
 
+// swiftlint:disable type_body_length
 struct VideoPlayerView: View {
     let cameras: [CameraFeed]
     let existingPlayer: AVPlayer?
@@ -116,6 +181,9 @@ struct VideoPlayerView: View {
     // UI feedback
     @State private var showSaveSuccess = false
     @State private var showSaveError = false
+
+    // Buffering / reconnect
+    @State private var retryTask: Task<Void, Never>?
 
     // Controls visibility
     @State private var showControls = true
@@ -159,6 +227,17 @@ struct VideoPlayerView: View {
             .ignoresSafeArea()
             #endif
 
+            // Buffering indicator
+            if playerObserver.isBuffering {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .scaleEffect(1.5)
+                    .tint(.white)
+                    .padding(20)
+                    .background(Color.black.opacity(0.45))
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+            }
+
             overlayControls
         }
         #if os(iOS) || os(tvOS) || os(visionOS)
@@ -186,12 +265,14 @@ struct VideoPlayerView: View {
             setupPlayer()
             configureAudioAndScreen()
             scheduleHide()
+            startRetryLoop()
         }
         .onDisappear {
             if isRecording { stopRecording() }
             cleanupPlayer()
             restoreAudioAndScreen()
             hideTask?.cancel()
+            retryTask?.cancel()
         }
         .alert(item: $playerObserver.playerError) { playerError in
             Alert(
@@ -366,6 +447,7 @@ struct VideoPlayerView: View {
         }
     }
 }
+// swiftlint:enable type_body_length
 
 // MARK: - Player Management
 private extension VideoPlayerView {
@@ -378,14 +460,39 @@ private extension VideoPlayerView {
                 kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
             ])
             let asset = AVURLAsset(url: url)
-            playerItem = AVPlayerItem(asset: asset)
-            playerItem?.add(output)
+            let item = AVPlayerItem(asset: asset)
+            item.add(output)
+            playerItem = item
             videoOutput = output
-            player = AVPlayer(playerItem: playerItem)
+            let newPlayer = AVPlayer(playerItem: item)
+            player = newPlayer
             player?.play()
+            playerObserver.observe(player: newPlayer, playerItem: item)
+        }
+    }
 
-            if let playerItem = playerItem {
-                playerObserver.observe(playerItem: playerItem)
+    func reconnectPlayer() {
+        guard existingPlayer == nil else { return }
+        if isRecording { stopRecording() }
+        playerObserver.stopObserving()
+        player?.pause()
+        if let output = videoOutput, let item = playerItem { item.remove(output) }
+        videoOutput = nil
+        player = nil
+        playerItem = nil
+        setupPlayer()
+        configureAudioAndScreen()
+    }
+
+    func startRetryLoop() {
+        guard existingPlayer == nil else { return }
+        retryTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(3))
+                guard !Task.isCancelled else { return }
+                if playerObserver.needsRetry {
+                    reconnectPlayer()
+                }
             }
         }
     }
@@ -394,9 +501,7 @@ private extension VideoPlayerView {
         if existingPlayer == nil {
             player?.pause()
             playerObserver.stopObserving()
-            if let output = videoOutput, let item = playerItem {
-                item.remove(output)
-            }
+            if let output = videoOutput, let item = playerItem { item.remove(output) }
             videoOutput = nil
             player = nil
             playerItem = nil

--- a/Rhizome/VideoPlayerView.swift
+++ b/Rhizome/VideoPlayerView.swift
@@ -4,11 +4,14 @@
 //
 //  Created by David Jensenius on 2025-01-11.
 //
+// swiftlint:disable file_length
 
 import Foundation
 import AVKit
 import Combine
 import SwiftUI
+import Photos
+import QuartzCore
 #if canImport(AVFoundation)
 import AVFoundation
 #endif
@@ -75,31 +78,54 @@ struct PlayerViewController: UIViewControllerRepresentable {
 #endif
 
 struct VideoPlayerView: View {
-    let cameraURL: String?
+    let cameras: [CameraFeed]
     let existingPlayer: AVPlayer?
+
+    @State private var activeCameraURL: String
     @State private var player: AVPlayer?
     @State private var playerItem: AVPlayerItem?
     @StateObject private var playerObserver = PlayerObserver()
+    @State private var videoOutput: AVPlayerItemVideoOutput?
 
-    // Initializer for URL-based player (current behavior)
-    init(cameraURL: String, onDismiss: (() -> Void)? = nil) {
-        self.cameraURL = cameraURL
-        self.existingPlayer = nil
-        self.onDismiss = onDismiss
-    }
+    // Recording state
+    @State private var isRecording = false
+    @State private var assetWriter: AVAssetWriter?
+    @State private var assetWriterInput: AVAssetWriterInput?
+    @State private var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
+    @State private var recordingTimer: Timer?
+    @State private var recordingStartTime: CMTime = .invalid
+    @State private var recordingOutputURL: URL?
 
-    // Initializer for existing player (replaces AZVideoPlayer)
-    init(player: AVPlayer, onDismiss: (() -> Void)? = nil) {
-        self.cameraURL = nil
-        self.existingPlayer = player
-        self.onDismiss = onDismiss
-    }
+    // UI feedback
+    @State private var showSaveSuccess = false
+    @State private var showSaveError = false
 
     @Environment(\.dismiss) var dismiss
     var onDismiss: (() -> Void)?
 
+    init(cameras: [CameraFeed], onDismiss: (() -> Void)? = nil) {
+        self.cameras = cameras
+        self.existingPlayer = nil
+        self.onDismiss = onDismiss
+        self._activeCameraURL = State(initialValue: cameras.first?.url ?? "")
+    }
+
+    init(cameraURL: String, onDismiss: (() -> Void)? = nil) {
+        self.cameras = [CameraFeed(id: "default", name: "Camera", url: cameraURL)]
+        self.existingPlayer = nil
+        self.onDismiss = onDismiss
+        self._activeCameraURL = State(initialValue: cameraURL)
+    }
+
+    init(player: AVPlayer, onDismiss: (() -> Void)? = nil) {
+        self.cameras = []
+        self.existingPlayer = player
+        self.onDismiss = onDismiss
+        self._activeCameraURL = State(initialValue: "")
+    }
+
     var body: some View {
-        ZStack(alignment: .topLeading) {
+        ZStack {
             Group {
                 #if os(iOS) || os(tvOS) || os(visionOS)
                 PlayerViewController(player: player)
@@ -111,98 +137,237 @@ struct VideoPlayerView: View {
             .ignoresSafeArea()
             #endif
 
-            #if os(iOS)
-            Button(action: {
-                if let onDismiss = onDismiss {
-                    onDismiss()
-                } else {
-                    dismiss()
-                }
-            }, label: {
-                Image(systemName: "chevron.left")
-                    .font(.title3)
-                    .foregroundColor(.white)
-                    .padding(12)
-                    .background(Color.black.opacity(0.5))
-                    .clipShape(Circle())
-            })
-            .padding(.leading, 16)
-            .padding(.top, 48)
-            .zIndex(1)
-            #endif
-
-            #if os(macOS)
-            Button(action: {
-                NSApplication.shared.windows.first?.toggleFullScreen(nil)
-            }, label: {
-                Image(systemName: "arrow.up.left.and.arrow.down.right")
-                    .font(.title3)
-                    .foregroundColor(.white)
-                    .padding(12)
-                    .background(Color.black.opacity(0.5))
-                    .clipShape(Circle())
-            })
-            .padding(.trailing, 16)
-            .padding(.top, 16)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-            .zIndex(100)
-            #endif
+            overlayControls
         }
-            #if os(iOS) || os(tvOS) || os(visionOS)
-            .ignoresSafeArea()
-            #endif
-            #if os(tvOS)
-            .toolbar(.hidden, for: .tabBar)
-            #endif
-            .onAppear {
-                setupPlayer()
-                configureAudioAndScreen()
-            }
-            .onDisappear {
-                cleanupPlayer()
-                restoreAudioAndScreen()
-            }
-            .alert(item: $playerObserver.playerError) { playerError in
-                Alert(
-                    title: Text("Playback Error"),
-                    message: Text(playerError.error.localizedDescription),
-                    dismissButton: .default(Text("OK"))
-                )
-            }
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        .ignoresSafeArea()
+        #endif
+        #if os(tvOS)
+        .toolbar(.hidden, for: .tabBar)
+        #endif
+        .onAppear {
+            setupPlayer()
+            configureAudioAndScreen()
+        }
+        .onDisappear {
+            if isRecording { stopRecording() }
+            cleanupPlayer()
+            restoreAudioAndScreen()
+        }
+        .alert(item: $playerObserver.playerError) { playerError in
+            Alert(
+                title: Text("Playback Error"),
+                message: Text(playerError.error.localizedDescription),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+        .alert("Saved!", isPresented: $showSaveSuccess) {
+            Button("OK") {}
+        } message: {
+            Text("Saved to your photo library.")
+        }
+        .alert("Save Failed", isPresented: $showSaveError) {
+            Button("OK") {}
+        } message: {
+            Text("Could not save to photo library. Please check permissions in Settings.")
+        }
     }
 
-    private func setupPlayer() {
+    // MARK: - Overlay Controls
+
+    @ViewBuilder
+    private var overlayControls: some View {
+        #if os(iOS) || os(visionOS)
+        VStack(spacing: 0) {
+            HStack(alignment: .top) {
+                Button(action: {
+                    if let onDismiss = onDismiss {
+                        onDismiss()
+                    } else {
+                        dismiss()
+                    }
+                }, label: {
+                    Image(systemName: "chevron.left")
+                        .font(.title3)
+                        .foregroundColor(.white)
+                        .padding(12)
+                        .background(Color.black.opacity(0.5))
+                        .clipShape(Circle())
+                })
+                .padding(.leading, 16)
+
+                Spacer()
+
+                HStack(spacing: 12) {
+                    Button(action: takeScreenshot) {
+                        Image(systemName: "camera.fill")
+                            .font(.title3)
+                            .foregroundColor(.white)
+                            .padding(12)
+                            .background(Color.black.opacity(0.5))
+                            .clipShape(Circle())
+                    }
+                    Button(
+                        action: { isRecording ? stopRecording() : startRecording() },
+                        label: {
+                            Image(systemName: isRecording ? "stop.circle.fill" : "record.circle")
+                                .font(.title3)
+                                .foregroundColor(isRecording ? .red : .white)
+                                .padding(12)
+                                .background(Color.black.opacity(0.5))
+                                .clipShape(Circle())
+                        }
+                    )
+                }
+                .padding(.trailing, 16)
+            }
+            .padding(.top, 48)
+
+            Spacer()
+
+            if cameras.count > 1 {
+                cameraSwitcher
+                    .padding(.bottom, 40)
+            }
+        }
+        .zIndex(1)
+        #elseif os(macOS)
+        VStack(spacing: 0) {
+            HStack(alignment: .top) {
+                Spacer()
+                HStack(spacing: 10) {
+                    Button(action: takeScreenshot) {
+                        Image(systemName: "camera.fill")
+                            .font(.title3)
+                            .foregroundColor(.white)
+                            .padding(12)
+                            .background(Color.black.opacity(0.5))
+                            .clipShape(Circle())
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(
+                        action: { isRecording ? stopRecording() : startRecording() },
+                        label: {
+                            Image(systemName: isRecording ? "stop.circle.fill" : "record.circle")
+                                .font(.title3)
+                                .foregroundColor(isRecording ? .red : .white)
+                                .padding(12)
+                                .background(Color.black.opacity(0.5))
+                                .clipShape(Circle())
+                        }
+                    )
+                    .buttonStyle(.plain)
+
+                    Button(action: {
+                        NSApplication.shared.windows.first?.toggleFullScreen(nil)
+                    }, label: {
+                        Image(systemName: "arrow.up.left.and.arrow.down.right")
+                            .font(.title3)
+                            .foregroundColor(.white)
+                            .padding(12)
+                            .background(Color.black.opacity(0.5))
+                            .clipShape(Circle())
+                    })
+                    .buttonStyle(.plain)
+                }
+                .padding(.trailing, 16)
+                .padding(.top, 16)
+            }
+
+            Spacer()
+
+            if cameras.count > 1 {
+                cameraSwitcher
+                    .padding(.bottom, 20)
+            }
+        }
+        .zIndex(100)
+        #elseif os(tvOS)
+        if cameras.count > 1 {
+            VStack {
+                Spacer()
+                cameraSwitcher
+                    .padding(.bottom, 60)
+            }
+            .zIndex(1)
+        }
+        #endif
+    }
+
+    @ViewBuilder
+    private var cameraSwitcher: some View {
+        HStack(spacing: 10) {
+            ForEach(cameras) { camera in
+                Button(camera.name) {
+                    if camera.url != activeCameraURL {
+                        switchCamera(to: camera)
+                    }
+                }
+                .font(.subheadline.weight(.semibold))
+                .padding(.horizontal, 18)
+                .padding(.vertical, 9)
+                .background(
+                    camera.url == activeCameraURL
+                        ? Color.white.opacity(0.9)
+                        : Color.black.opacity(0.5)
+                )
+                .foregroundColor(camera.url == activeCameraURL ? .black : .white)
+                .clipShape(Capsule())
+                #if os(macOS) || os(tvOS)
+                .buttonStyle(.plain)
+                #endif
+            }
+        }
+    }
+}
+
+// MARK: - Player Management
+private extension VideoPlayerView {
+    func setupPlayer() {
         if let existingPlayer = existingPlayer {
-            // Use existing player (replaces AZVideoPlayer functionality)
             player = existingPlayer
             player?.play()
-        } else if let cameraURL = cameraURL, let url = URL(string: cameraURL) {
-            // Create new player from URL (current VideoPlayerView behavior)
+        } else if let url = URL(string: activeCameraURL) {
+            let output = AVPlayerItemVideoOutput(pixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+            ])
             let asset = AVURLAsset(url: url)
             playerItem = AVPlayerItem(asset: asset)
+            playerItem?.add(output)
+            videoOutput = output
             player = AVPlayer(playerItem: playerItem)
             player?.play()
 
-            // Observe AVPlayerItem status and error using block-based KVO
             if let playerItem = playerItem {
                 playerObserver.observe(playerItem: playerItem)
             }
         }
     }
 
-    private func cleanupPlayer() {
-        // Only pause and cleanup if we created the player ourselves
+    func cleanupPlayer() {
         if existingPlayer == nil {
             player?.pause()
             playerObserver.stopObserving()
+            if let output = videoOutput, let item = playerItem {
+                item.remove(output)
+            }
+            videoOutput = nil
             player = nil
             playerItem = nil
         }
     }
 
-    private func configureAudioAndScreen() {
+    func switchCamera(to camera: CameraFeed) {
+        if isRecording { stopRecording() }
+        cleanupPlayer()
+        activeCameraURL = camera.url
+        setupPlayer()
+        configureAudioAndScreen()
+    }
+
+    func configureAudioAndScreen() {
         #if os(iOS) || os(tvOS) || os(visionOS)
-        // Play audio even in silent mode
         do {
             try AVAudioSession.sharedInstance().setCategory(.playback, mode: .moviePlayback)
             try AVAudioSession.sharedInstance().setActive(true)
@@ -212,15 +377,180 @@ struct VideoPlayerView: View {
         #endif
 
         #if os(iOS)
-        // Keep screen awake
         UIApplication.shared.isIdleTimerDisabled = true
         #endif
     }
 
-    private func restoreAudioAndScreen() {
+    func restoreAudioAndScreen() {
         #if os(iOS)
-        // Allow screen to sleep
         UIApplication.shared.isIdleTimerDisabled = false
         #endif
     }
+
 }
+
+// MARK: - Screenshot & Recording
+private extension VideoPlayerView {
+    func takeScreenshot() {
+        guard let output = videoOutput else { return }
+        let hostTime = CACurrentMediaTime()
+        let itemTime = output.itemTime(forHostTime: hostTime)
+        guard output.hasNewPixelBuffer(forItemTime: itemTime),
+              let pixelBuffer = output.copyPixelBuffer(forItemTime: itemTime, itemTimeForDisplay: nil)
+        else { return }
+
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+        let context = CIContext()
+        guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else { return }
+
+        #if os(iOS) || os(visionOS)
+        let image = UIImage(cgImage: cgImage)
+        saveImageToPhotos(image)
+        #elseif os(macOS)
+        let image = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
+        saveImageToPhotos(image)
+        #endif
+    }
+
+    func startRecording() {
+        guard let playerItem = playerItem, let output = videoOutput else { return }
+
+        let size = playerItem.presentationSize
+        let width = size.width > 0 ? Int(size.width) : 1920
+        let height = size.height > 0 ? Int(size.height) : 1080
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rhizome_\(Int(Date().timeIntervalSince1970)).mp4")
+
+        guard let writer = try? AVAssetWriter(outputURL: tempURL, fileType: .mp4) else { return }
+
+        let videoSettings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: width,
+            AVVideoHeightKey: height
+        ]
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
+        input.expectsMediaDataInRealTime = true
+
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height
+            ]
+        )
+
+        writer.add(input)
+        writer.startWriting()
+        writer.startSession(atSourceTime: .zero)
+
+        assetWriter = writer
+        assetWriterInput = input
+        pixelBufferAdaptor = adaptor
+        recordingStartTime = .invalid
+        recordingOutputURL = tempURL
+        isRecording = true
+
+        recordingTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { _ in
+            Task { @MainActor in
+                self.captureRecordingFrame(output: output)
+            }
+        }
+    }
+
+    func captureRecordingFrame(output: AVPlayerItemVideoOutput) {
+        guard let writer = assetWriter,
+              let input = assetWriterInput,
+              let adaptor = pixelBufferAdaptor,
+              writer.status == .writing,
+              input.isReadyForMoreMediaData else { return }
+
+        let hostTime = CACurrentMediaTime()
+        let itemTime = output.itemTime(forHostTime: hostTime)
+
+        guard output.hasNewPixelBuffer(forItemTime: itemTime),
+              let pixelBuffer = output.copyPixelBuffer(forItemTime: itemTime, itemTimeForDisplay: nil)
+        else { return }
+
+        if recordingStartTime == .invalid {
+            recordingStartTime = itemTime
+        }
+        let presentationTime = CMTimeSubtract(itemTime, recordingStartTime)
+        adaptor.append(pixelBuffer, withPresentationTime: presentationTime)
+    }
+
+    func stopRecording() {
+        recordingTimer?.invalidate()
+        recordingTimer = nil
+        isRecording = false
+
+        assetWriterInput?.markAsFinished()
+        let writer = assetWriter
+        let url = recordingOutputURL
+        assetWriter = nil
+        assetWriterInput = nil
+        pixelBufferAdaptor = nil
+        recordingOutputURL = nil
+        recordingStartTime = .invalid
+
+        writer?.finishWriting {
+            guard let url = url else { return }
+            Task { @MainActor in
+                self.saveVideoToPhotos(url: url)
+            }
+        }
+    }
+
+}
+
+// MARK: - Photos Saving
+private extension VideoPlayerView {
+    #if os(iOS) || os(macOS) || os(visionOS)
+    func saveImageToPhotos(_ image: PHCompatibleImage) {
+        PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
+            guard status == .authorized || status == .limited else {
+                Task { @MainActor in self.showSaveError = true }
+                return
+            }
+            PHPhotoLibrary.shared().performChanges(
+                { PHAssetChangeRequest.creationRequestForAsset(from: image) },
+                completionHandler: { success, _ in
+                    Task { @MainActor in
+                        if success { self.showSaveSuccess = true } else { self.showSaveError = true }
+                    }
+                }
+            )
+        }
+    }
+
+    func saveVideoToPhotos(url: URL) {
+        PHPhotoLibrary.requestAuthorization(for: .addOnly) { status in
+            guard status == .authorized || status == .limited else {
+                Task { @MainActor in self.showSaveError = true }
+                return
+            }
+            PHPhotoLibrary.shared().performChanges(
+                { PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url) },
+                completionHandler: { success, _ in
+                    Task { @MainActor in
+                        try? FileManager.default.removeItem(at: url)
+                        if success { self.showSaveSuccess = true } else { self.showSaveError = true }
+                    }
+                }
+            )
+        }
+    }
+    #else
+    func saveVideoToPhotos(url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+    #endif
+}
+
+// Platform-unified image type for PHAssetChangeRequest.creationRequestForAsset(from:)
+#if os(iOS) || os(visionOS)
+typealias PHCompatibleImage = UIImage
+#elseif os(macOS)
+typealias PHCompatibleImage = NSImage
+#endif

--- a/Rhizome/VideoPlayerView.swift
+++ b/Rhizome/VideoPlayerView.swift
@@ -100,6 +100,10 @@ struct VideoPlayerView: View {
     @State private var showSaveSuccess = false
     @State private var showSaveError = false
 
+    // Controls visibility
+    @State private var showControls = true
+    @State private var hideTask: Task<Void, Never>?
+
     @Environment(\.dismiss) var dismiss
     var onDismiss: (() -> Void)?
 
@@ -142,17 +146,34 @@ struct VideoPlayerView: View {
         #if os(iOS) || os(tvOS) || os(visionOS)
         .ignoresSafeArea()
         #endif
+        #if os(iOS) || os(visionOS)
+        .simultaneousGesture(TapGesture().onEnded { toggleControls() })
+        #elseif os(macOS)
+        .onContinuousHover { phase in
+            switch phase {
+            case .active:
+                withAnimation(.easeInOut(duration: 0.25)) { showControls = true }
+                scheduleHide()
+            case .ended:
+                scheduleHide()
+            }
+        }
+        #elseif os(tvOS)
+        .simultaneousGesture(TapGesture().onEnded { toggleControls() })
+        #endif
         #if os(tvOS)
         .toolbar(.hidden, for: .tabBar)
         #endif
         .onAppear {
             setupPlayer()
             configureAudioAndScreen()
+            scheduleHide()
         }
         .onDisappear {
             if isRecording { stopRecording() }
             cleanupPlayer()
             restoreAudioAndScreen()
+            hideTask?.cancel()
         }
         .alert(item: $playerObserver.playerError) { playerError in
             Alert(
@@ -230,6 +251,8 @@ struct VideoPlayerView: View {
                     .padding(.bottom, 40)
             }
         }
+        .opacity(showControls ? 1 : 0)
+        .animation(.easeInOut(duration: 0.25), value: showControls)
         .zIndex(1)
         #elseif os(macOS)
         VStack(spacing: 0) {
@@ -282,6 +305,8 @@ struct VideoPlayerView: View {
                     .padding(.bottom, 20)
             }
         }
+        .opacity(showControls ? 1 : 0)
+        .animation(.easeInOut(duration: 0.25), value: showControls)
         .zIndex(100)
         #elseif os(tvOS)
         if cameras.count > 1 {
@@ -290,6 +315,8 @@ struct VideoPlayerView: View {
                 cameraSwitcher
                     .padding(.bottom, 60)
             }
+            .opacity(showControls ? 1 : 0)
+            .animation(.easeInOut(duration: 0.25), value: showControls)
             .zIndex(1)
         }
         #endif
@@ -364,6 +391,24 @@ private extension VideoPlayerView {
         activeCameraURL = camera.url
         setupPlayer()
         configureAudioAndScreen()
+    }
+
+    func scheduleHide() {
+        hideTask?.cancel()
+        hideTask = Task {
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            withAnimation(.easeInOut(duration: 0.25)) { showControls = false }
+        }
+    }
+
+    func toggleControls() {
+        withAnimation(.easeInOut(duration: 0.25)) { showControls.toggle() }
+        if showControls {
+            scheduleHide()
+        } else {
+            hideTask?.cancel()
+        }
     }
 
     func configureAudioAndScreen() {

--- a/RhizomeMac/ContentView.swift
+++ b/RhizomeMac/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import AVKit
 
 struct ContentView: View {
-    var cameraURL: String
+    var cameras: [CameraFeed]
     var rhizomeSchedule: Appointments?
     @State var inPlayroom = false
     @State var path = [Int]()
@@ -45,7 +45,7 @@ struct ContentView: View {
                 showRhizome
             }.navigationDestination(for: Int.self) { selection in
                 if selection == 1 {
-                    VideoPlayerView(cameraURL: cameraURL)
+                    VideoPlayerView(cameras: cameras)
                 }
             }
         }

--- a/RhizomeMac/Info.plist
+++ b/RhizomeMac/Info.plist
@@ -21,5 +21,7 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Rhizome saves screenshots and video clips from camera feeds to your photo library.</string>
 </dict>
 </plist>

--- a/RhizomeMac/RhizomeMac.entitlements
+++ b/RhizomeMac/RhizomeMac.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.personal-information.photos-library</key>
+	<true/>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:api.fluxhaus.io</string>

--- a/RhizomeMac/RhizomeMacApp.swift
+++ b/RhizomeMac/RhizomeMacApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct RhizomeMacApp: App {
     @State private var whereWeAre = WhereWeAre()
-    @State var cameraURL = ""
+    @State var cameras: [CameraFeed] = []
     @State var images: [String] = []
     @State var rhizomeSchedule: Appointments?
     @State var newsUrl: String?
@@ -26,7 +26,7 @@ struct RhizomeMacApp: App {
                         if ((object.userInfo?["keysComplete"]) != nil) == true {
                             if object.object != nil {
                                 let configResponse = object.object! as? LoginResponse
-                                cameraURL = configResponse?.cameraURL ?? ""
+                                cameras = configResponse?.cameraFeeds ?? []
                                 images = configResponse?.rhizomeData.photos ?? []
                                 newsUrl = configResponse?.rhizomeData.news ?? nil
                                 rhizomeSchedule = configResponse?.rhizomeSchedule.appointments
@@ -43,7 +43,7 @@ struct RhizomeMacApp: App {
                 }
             } else {
                 TabView {
-                    ContentView(cameraURL: cameraURL, rhizomeSchedule: rhizomeSchedule)
+                    ContentView(cameras: cameras, rhizomeSchedule: rhizomeSchedule)
                         .tabItem {
                             Label("Watch", systemImage: "tv")
                         }

--- a/RhizomeMacTests/RhizomeMacTests.swift
+++ b/RhizomeMacTests/RhizomeMacTests.swift
@@ -59,21 +59,21 @@ import SwiftUI
 // MARK: - ContentView Tests
 
 @MainActor @Test func macContentViewInitialization() throws {
-    let cameraURL = "https://example.com/stream"
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
     let schedule: Appointments? = nil
-    let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: schedule)
+    let contentView = ContentView(cameras: cameras, rhizomeSchedule: schedule)
     #expect(type(of: contentView) == ContentView.self)
 }
 
 @MainActor @Test func macContentViewWithSchedule() throws {
-    let cameraURL = "https://example.com/stream"
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
     let daycare = AppointmentsDaycare(
         startDate: "Thursday, 8/14/2025 9:00 am",
         rId: 1,
         type: "Daycare | Full Day"
     )
     let appointments = Appointments(nextReservation: daycare)
-    let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: appointments)
+    let contentView = ContentView(cameras: cameras, rhizomeSchedule: appointments)
     #expect(type(of: contentView) == ContentView.self)
 }
 

--- a/RhizomeTV/ContentView.swift
+++ b/RhizomeTV/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import AVKit
 
 struct ContentView: View {
-    var cameraURL: String
+    var cameras: [CameraFeed]
     var rhizomeSchedule: Appointments?
     @State var inPlayroom = false
     @State var path = [Int]()
@@ -49,7 +49,7 @@ struct ContentView: View {
                     .padding(50)
             }.navigationDestination(for: Int.self) { selection in
                 if selection == 1 {
-                    VideoPlayerView(cameraURL: cameraURL)
+                    VideoPlayerView(cameras: cameras)
                 }
             }
         }
@@ -121,5 +121,5 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView(cameraURL: "")
+    ContentView(cameras: [], rhizomeSchedule: nil)
 }

--- a/RhizomeTV/RhizomeTVApp.swift
+++ b/RhizomeTV/RhizomeTVApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct RhizomeTVApp: App {
     @State private var whereWeAre = WhereWeAre()
-    @State var cameraURL = ""
+    @State var cameras: [CameraFeed] = []
     @State var images: [String] = []
     @State var rhizomeSchedule: Appointments?
     @State var newsUrl: String?
@@ -29,7 +29,7 @@ struct RhizomeTVApp: App {
                         if ((object.userInfo?["keysComplete"]) != nil) == true {
                             if object.object != nil {
                                 let configResponse = object.object! as? LoginResponse
-                                cameraURL = configResponse?.cameraURL ?? ""
+                                cameras = configResponse?.cameraFeeds ?? []
                                 images = configResponse?.rhizomeData.photos ?? []
                                 newsUrl = configResponse?.rhizomeData.news ?? nil
                                 rhizomeSchedule = configResponse?.rhizomeSchedule.appointments
@@ -48,7 +48,7 @@ struct RhizomeTVApp: App {
                 }
             } else {
                 RhizomeTabs(
-                    cameraUrl: cameraURL,
+                    cameras: cameras,
                     rhizomeSchedule: rhizomeSchedule,
                     newsUrl: newsUrl ?? "",
                     images: images

--- a/RhizomeTV/RhizomeTabs.swift
+++ b/RhizomeTV/RhizomeTabs.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct RhizomeTabs: View {
-    var cameraUrl: String
+    var cameras: [CameraFeed]
     var rhizomeSchedule: Appointments?
     var newsUrl: String
     var images: [String]
@@ -17,7 +17,7 @@ struct RhizomeTabs: View {
     var body: some View {
         TabView(selection: $selectedTab) {
             Tab("Watch", systemImage: "tv", value: "0") {
-                ContentView(cameraURL: cameraUrl, rhizomeSchedule: rhizomeSchedule)
+                ContentView(cameras: cameras, rhizomeSchedule: rhizomeSchedule)
                     .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
 
             }

--- a/RhizomeTVTests/RhizomeTVTests.swift
+++ b/RhizomeTVTests/RhizomeTVTests.swift
@@ -174,7 +174,7 @@ func authenticationErrorInitWithOtherError() throws {
 @Test
 func rhizomeTabsInitialization() throws {
     // Given: RhizomeTabs parameters
-    let cameraUrl = "https://example.com/stream"
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
     let daycare = AppointmentsDaycare(
         startDate: "Thursday, 8/14/2025 9:00 am",
         rId: 1,
@@ -186,14 +186,14 @@ func rhizomeTabsInitialization() throws {
 
     // When: Creating RhizomeTabs
     let tabs = RhizomeTabs(
-        cameraUrl: cameraUrl,
+        cameras: cameras,
         rhizomeSchedule: appointments,
         newsUrl: newsUrl,
         images: images
     )
 
     // Then: Should initialize correctly
-    #expect(tabs.cameraUrl == cameraUrl)
+    #expect(tabs.cameras[0].url == cameras[0].url)
     #expect(tabs.newsUrl == newsUrl)
     #expect(tabs.images.count == 2)
 }
@@ -210,7 +210,7 @@ func authenticationControllerPerformance() throws {
 @MainActor
 @Test(.timeLimit(.minutes(1)))
 func rhizomeTabsPerformance() throws {
-    let cameraUrl = "https://example.com/stream"
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
     let daycare = AppointmentsDaycare(
         startDate: "Thursday, 8/14/2025 9:00 am",
         rId: 1,
@@ -221,7 +221,7 @@ func rhizomeTabsPerformance() throws {
     let images = Array(1...50).map { "image\($0).jpg" }
 
     _ = RhizomeTabs(
-        cameraUrl: cameraUrl,
+        cameras: cameras,
         rhizomeSchedule: appointments,
         newsUrl: newsUrl,
         images: images

--- a/RhizomeTests/ContentViewTests.swift
+++ b/RhizomeTests/ContentViewTests.swift
@@ -16,15 +16,15 @@ struct ContentViewTests {
     @Test
     func contentViewInitialization() {
         // Given: Parameters for ContentView
-        let cameraURL = "https://example.com/stream"
+        let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
         let daycare = AppointmentsDaycare(startDate: "Thursday, 8/14/2025 9:00 am", rId: 1, type: "Daycare | Full Day")
         let appointments = Appointments(nextReservation: daycare)
 
         // When: Creating ContentView
-        let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: appointments)
+        let contentView = ContentView(cameras: cameras, rhizomeSchedule: appointments)
 
         // Then: Should initialize correctly
-        #expect(contentView.cameraURL == cameraURL)
+        #expect(contentView.cameras[0].url == cameras[0].url)
         #expect(contentView.rhizomeSchedule != nil)
         #expect(!contentView.inPlayroom)
     }
@@ -32,13 +32,13 @@ struct ContentViewTests {
     @Test
     func contentViewInitializationWithNilSchedule() {
         // Given: Parameters with nil schedule
-        let cameraURL = "https://example.com/stream"
+        let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
 
         // When: Creating ContentView with nil schedule
-        let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: nil)
+        let contentView = ContentView(cameras: cameras, rhizomeSchedule: nil)
 
         // Then: Should handle nil schedule gracefully
-        #expect(contentView.cameraURL == cameraURL)
+        #expect(contentView.cameras[0].url == cameras[0].url)
         #expect(contentView.rhizomeSchedule == nil)
         #expect(!contentView.inPlayroom)
     }
@@ -46,7 +46,7 @@ struct ContentViewTests {
     @Test
     func parseScheduleWithTodayAppointment() {
         // Given: A ContentView with an appointment for today
-        let cameraURL = "https://example.com/stream"
+        let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
 
         let torontoTimeZone = TimeZone(identifier: "America/Toronto")!
         let formatter = DateFormatter()
@@ -56,7 +56,7 @@ struct ContentViewTests {
 
         let daycare = AppointmentsDaycare(startDate: todayString, rId: 1, type: "Daycare | Full Day")
         let appointments = Appointments(nextReservation: daycare)
-        let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: appointments)
+        let contentView = ContentView(cameras: cameras, rhizomeSchedule: appointments)
 
         // When/Then: parseSchedule() should complete without crashing.
         // Note: @State property changes are not observable outside SwiftUI's
@@ -67,7 +67,7 @@ struct ContentViewTests {
     @Test
     func parseScheduleWithFutureAppointment() {
         // Given: A ContentView with a future appointment
-        let cameraURL = "https://example.com/stream"
+        let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
 
         let torontoTimeZone = TimeZone(identifier: "America/Toronto")!
         let tomorrow = Date().addingTimeInterval(48 * 60 * 60)
@@ -78,7 +78,7 @@ struct ContentViewTests {
 
         let daycare = AppointmentsDaycare(startDate: tomorrowString, rId: 1, type: "Daycare | Full Day")
         let appointments = Appointments(nextReservation: daycare)
-        let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: appointments)
+        let contentView = ContentView(cameras: cameras, rhizomeSchedule: appointments)
 
         // When: Parsing the schedule
         contentView.parseSchedule()
@@ -90,8 +90,8 @@ struct ContentViewTests {
     @Test
     func parseScheduleWithNilSchedule() {
         // Given: A ContentView with nil schedule
-        let cameraURL = "https://example.com/stream"
-        let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: nil)
+        let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
+        let contentView = ContentView(cameras: cameras, rhizomeSchedule: nil)
 
         // When: Parsing the schedule
         contentView.parseSchedule()

--- a/RhizomeTests/IntegrationTests.swift
+++ b/RhizomeTests/IntegrationTests.swift
@@ -132,6 +132,8 @@ final class IntegrationTests: XCTestCase {
         // When: Simulating complete authentication
         let testResponse = LoginResponse(
             cameraURL: "https://example.com/stream",
+            romperURL: nil,
+            gymURL: nil,
             rhizomeSchedule: RhizomeSchedule(
                 timestamp: "2024-06-18T10:00:00Z",
                 appointments: nil,
@@ -168,7 +170,10 @@ final class IntegrationTests: XCTestCase {
 
         let daycare = AppointmentsDaycare(startDate: todayString, rId: 1, type: "Daycare | Full Day")
         let appointments = Appointments(nextReservation: daycare)
-        var contentView = ContentView(cameraURL: "https://example.com/stream", rhizomeSchedule: appointments)
+        var contentView = ContentView(
+            cameras: [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")],
+            rhizomeSchedule: appointments
+        )
 
         // When: Parsing schedule
         contentView.parseSchedule()
@@ -268,7 +273,10 @@ final class IntegrationTests: XCTestCase {
         let daycare = AppointmentsDaycare(startDate: "Thursday, 8/14/2025 9:00 am", rId: 1, type: "Daycare | Full Day")
         let appointments = Appointments(nextReservation: daycare)
         let schedule = Schedule(newsUrl: "https://example.com/news", schedule: appointments)
-        var contentView = ContentView(cameraURL: "https://example.com/stream", rhizomeSchedule: appointments)
+        var contentView = ContentView(
+            cameras: [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")],
+            rhizomeSchedule: appointments
+        )
 
         // Then: Should handle large datasets efficiently
         XCTAssertEqual(gallery.images.count, 100)

--- a/RhizomeTests/NetworkTests.swift
+++ b/RhizomeTests/NetworkTests.swift
@@ -75,6 +75,8 @@ struct NetworkTests {
         // When: Posting login notification
         let testResponse = LoginResponse(
             cameraURL: "https://example.com/stream",
+            romperURL: nil,
+            gymURL: nil,
             rhizomeSchedule: RhizomeSchedule(
                 timestamp: "2024-06-18T10:00:00Z",
                 appointments: nil,

--- a/RhizomeVision/ContentView.swift
+++ b/RhizomeVision/ContentView.swift
@@ -11,7 +11,7 @@ import RealityKit
 import RealityKitContent
 
 struct ContentView: View {
-    var cameraURL: String
+    var cameras: [CameraFeed]
     var rhizomeSchedule: Appointments?
     @State private var showVideo = false
 
@@ -31,7 +31,7 @@ struct ContentView: View {
             }
         }
         .fullScreenCover(isPresented: $showVideo) {
-            VideoPlayerView(cameraURL: cameraURL)
+            VideoPlayerView(cameras: cameras)
         }
         .onAppear(perform: parseSchedule)
     }
@@ -101,5 +101,5 @@ struct ContentView: View {
 }
 
 #Preview(windowStyle: .automatic) {
-    ContentView(cameraURL: "")
+    ContentView(cameras: [], rhizomeSchedule: nil)
 }

--- a/RhizomeVision/Info.plist
+++ b/RhizomeVision/Info.plist
@@ -17,6 +17,8 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Rhizome saves screenshots and video clips from camera feeds to your photo library.</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationPreferredDefaultSceneSessionRole</key>

--- a/RhizomeVision/RhizomeVisionApp.swift
+++ b/RhizomeVision/RhizomeVisionApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct RhizomeVisionApp: App {
     @State private var whereWeAre = WhereWeAre()
-    @State var cameraURL = ""
+    @State var cameras: [CameraFeed] = []
     @State var images: [String] = []
     @State var rhizomeSchedule: Appointments?
     @State var newsUrl: String?
@@ -26,7 +26,7 @@ struct RhizomeVisionApp: App {
                         if ((object.userInfo?["keysComplete"]) != nil) == true {
                             if object.object != nil {
                                 let configResponse = object.object! as? LoginResponse
-                                cameraURL = configResponse?.cameraURL ?? ""
+                                cameras = configResponse?.cameraFeeds ?? []
                                 images = configResponse?.rhizomeData.photos ?? []
                                 newsUrl = configResponse?.rhizomeData.news ?? nil
                                 rhizomeSchedule = configResponse?.rhizomeSchedule.appointments
@@ -43,7 +43,7 @@ struct RhizomeVisionApp: App {
                 }
             } else {
                 TabView {
-                    ContentView(cameraURL: cameraURL, rhizomeSchedule: rhizomeSchedule)
+                    ContentView(cameras: cameras, rhizomeSchedule: rhizomeSchedule)
                         .tabItem {
                             Label("Watch", systemImage: "tv")
                         }

--- a/RhizomeVisionTests/RhizomeVisionTests.swift
+++ b/RhizomeVisionTests/RhizomeVisionTests.swift
@@ -14,7 +14,7 @@ import SwiftUI
 @MainActor
 @Test func visionContentViewInitialization() throws {
     // Given: ContentView parameters for visionOS
-    let cameraURL = "https://example.com/stream"
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
     let daycare = AppointmentsDaycare(
         startDate: "Thursday, 8/14/2025 9:00 am",
         rId: 1,
@@ -23,7 +23,7 @@ import SwiftUI
     let appointments = Appointments(nextReservation: daycare)
 
     // When: Creating ContentView
-    let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: appointments)
+    let contentView = ContentView(cameras: cameras, rhizomeSchedule: appointments)
 
     // Then: Should initialize correctly (avoid comparing non-optional to nil)
     #expect(type(of: contentView) == ContentView.self)
@@ -33,10 +33,10 @@ import SwiftUI
 @MainActor
 @Test func visionContentViewWithNilSchedule() throws {
     // Given: ContentView parameters with nil schedule
-    let cameraURL = "https://example.com/stream"
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
 
     // When: Creating ContentView with nil schedule
-    let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: nil)
+    let contentView = ContentView(cameras: cameras, rhizomeSchedule: nil)
 
     // Then: Should handle nil schedule gracefully
     #expect(type(of: contentView) == ContentView.self)
@@ -45,10 +45,10 @@ import SwiftUI
 @MainActor
 @Test func visionContentViewWithEmptyURL() throws {
     // Given: ContentView with empty camera URL
-    let cameraURL = ""
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "")]
 
     // When: Creating ContentView with empty URL
-    let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: nil)
+    let contentView = ContentView(cameras: cameras, rhizomeSchedule: nil)
 
     // Then: Should handle empty URL gracefully
     #expect(type(of: contentView) == ContentView.self)
@@ -57,7 +57,7 @@ import SwiftUI
 // MARK: - Performance Tests
 
 @Test(.timeLimit(.minutes(1))) func visionContentViewPerformance() throws {
-    let cameraURL = "https://example.com/stream"
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
     let daycare = AppointmentsDaycare(
         startDate: "Thursday, 8/14/2025 9:00 am",
         rId: 1,
@@ -65,7 +65,7 @@ import SwiftUI
     )
     let appointments = Appointments(nextReservation: daycare)
 
-    _ = ContentView(cameraURL: cameraURL, rhizomeSchedule: appointments)
+    _ = ContentView(cameras: cameras, rhizomeSchedule: appointments)
 }
 
 // MARK: - VisionOS Specific Tests
@@ -73,7 +73,7 @@ import SwiftUI
 @MainActor
 @Test func visionContentViewHandlesRealityKitIntegration() throws {
     // Given: Parameters that would use RealityKit
-    let cameraURL = "https://example.com/stream"
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
     let daycare = AppointmentsDaycare(
         startDate: "Thursday, 8/14/2025 9:00 am",
         rId: 1,
@@ -82,7 +82,7 @@ import SwiftUI
     let appointments = Appointments(nextReservation: daycare)
 
     // When: Creating ContentView (which should integrate with RealityKit)
-    let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: appointments)
+    let contentView = ContentView(cameras: cameras, rhizomeSchedule: appointments)
 
     // Then: Should not crash when RealityKit components are involved
     #expect(type(of: contentView) == ContentView.self)
@@ -92,7 +92,7 @@ import SwiftUI
 @MainActor
 @Test func visionContentViewWithComplexSchedule() throws {
     // Given: Complex schedule data
-    let cameraURL = "https://example.com/stream"
+    let cameras = [CameraFeed(id: "toybox", name: "Toybox", url: "https://example.com/stream")]
     let daycare = AppointmentsDaycare(
         startDate: "Thursday, 8/14/2025 9:00 am",
         rId: 1,
@@ -101,7 +101,7 @@ import SwiftUI
     let appointments = Appointments(nextReservation: daycare)
 
     // When: Creating ContentView with complex schedule
-    let contentView = ContentView(cameraURL: cameraURL, rhizomeSchedule: appointments)
+    let contentView = ContentView(cameras: cameras, rhizomeSchedule: appointments)
 
     // Then: Should handle complex data gracefully
     #expect(type(of: contentView) == ContentView.self)


### PR DESCRIPTION
## What's new in v1.4.0

### 🎥 Multi-camera switching
- New `CameraFeed` model with Toybox (default), Romper, and Gym cameras
- `LoginResponse` now decodes `romperURL` and `gymURL` from the API
- Pill-button switcher overlay on the video player for iOS, macOS, visionOS (bottom of screen)
- Camera picker on the tvOS home screen via RhizomeTabs/ContentView

### 📷 Screenshots
- Tap the camera icon (top-right of video player) to capture the current frame
- Saved to the default photo library via `AVPlayerItemVideoOutput` + Photos framework
- iOS, macOS, and visionOS supported

### ⏺ Video recording
- Tap the record button to start capturing; tap stop to finish
- Uses `AVAssetWriter` + `AVPlayerItemVideoOutput` at 30 fps
- Saved to the default photo library as an MP4
- iOS, macOS, and visionOS supported

### 🔒 Permissions
- `NSPhotoLibraryAddUsageDescription` added to iOS and visionOS Info.plist
- `NSPhotoLibraryUsageDescription` + `photos-library` entitlement added to macOS

### 🏗 Server
See companion PR in FluxHaus-Server: adds `CAMERA_ROMPER_URL` and `CAMERA_GYM_URL` env vars, returned as `romperURL` and `gymURL` in the API response.